### PR TITLE
String.codepoints returns an Enumerator in Ruby 1.9 if called without block

### DIFF
--- a/lib/simple_xlsx_reader.rb
+++ b/lib/simple_xlsx_reader.rb
@@ -219,7 +219,7 @@ module SimpleXlsxReader
       # 'BZA' = 26 * 26 * 2 + 26 * 26 + 1
       def column_letter_to_number(column_letter)
         pow = -1
-        column_letter.codepoints.reverse.inject(0) do |acc, charcode|
+        column_letter.codepoints.to_a.reverse.inject(0) do |acc, charcode|
           pow += 1
           acc + 26**pow * (charcode - 64)
         end


### PR DESCRIPTION
I don't know if Ruby 1.9 is supported, but the only issue I ran into while testing is that `String.codepoints` returns an `Array` in 2.1 instead of an `Enumerator`. This will make it work in Ruby 1.9.
