### PR TITLE
Restore ability to parse io strings

### DIFF
--- a/lib/simple_xlsx_reader.rb
+++ b/lib/simple_xlsx_reader.rb
@@ -42,8 +42,11 @@ module SimpleXlsxReader
     end
 
     def open(file_path)
-      Document.new(file_path).tap(&:sheets)
+      Document.new(file_path: file_path).tap(&:sheets)
     end
-    alias parse open
+    
+    def parse(string_or_io)
+      Document.new(string_or_io: string_or_io).tap(&:sheets)
+    end
   end
 end

--- a/lib/simple_xlsx_reader/document.rb
+++ b/lib/simple_xlsx_reader/document.rb
@@ -8,14 +8,16 @@ module SimpleXlsxReader
   # Main class for the public API. See the README for usage examples,
   # or read the code, it's pretty friendly.
   class Document
-    attr_reader :file_path
+    attr_reader :string_or_io
 
-    def initialize(file_path)
-      @file_path = file_path
+    def initialize(legacy_file_path = nil, file_path: nil, string_or_io: nil)
+      fail(ArgumentError, 'either file_path or string_or_io must be provided') if legacy_file_path.nil? && file_path.nil? && string_or_io.nil?
+  
+      @string_or_io = string_or_io || File.new(legacy_file_path || file_path)
     end
 
     def sheets
-      @sheets ||= Loader.new(file_path).init_sheets
+      @sheets ||= Loader.new(string_or_io).init_sheets
     end
 
     # Expensive because it slurps all the sheets into memory,

--- a/lib/simple_xlsx_reader/loader.rb
+++ b/lib/simple_xlsx_reader/loader.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module SimpleXlsxReader
-  class Loader < Struct.new(:file_path)
+  class Loader < Struct.new(:string_or_io)
     attr_accessor :shared_strings, :sheet_parsers, :sheet_toc, :style_types, :base_date
 
     def init_sheets
       ZipReader.new(
-        file_path: file_path,
+        string_or_io: string_or_io,
         loader: self
       ).read
 
@@ -19,12 +19,12 @@ module SimpleXlsxReader
       end
     end
 
-    ZipReader = Struct.new(:file_path, :loader, keyword_init: true) do
+    ZipReader = Struct.new(:string_or_io, :loader, keyword_init: true) do
       attr_reader :zip
 
       def initialize(*args)
         super
-        @zip = SimpleXlsxReader::Zip.open(file_path)
+        @zip = SimpleXlsxReader::Zip.open_buffer(string_or_io)
       end
 
       def read

--- a/test/simple_xlsx_reader_test.rb
+++ b/test/simple_xlsx_reader_test.rb
@@ -18,6 +18,7 @@ describe SimpleXlsxReader do
 
   let(:sesame_street_blog_file_path) { File.join(File.dirname(__FILE__), 'sesame_street_blog.xlsx') }
   let(:sesame_street_blog_io) { File.new(sesame_street_blog_file_path) }
+  let(:sesame_street_blog_string) { IO.read(sesame_street_blog_file_path) }
 
   let(:expected_result) do
     {
@@ -50,6 +51,14 @@ describe SimpleXlsxReader do
       let(:subject) { SimpleXlsxReader.parse(sesame_street_blog_io) }
 
       it 'reads an xlsx buffer into a hash of {[sheet name] => [data]}' do
+        _(subject.to_hash).must_equal(expected_result)
+      end
+    end
+
+    describe 'load from string' do
+      let(:subject) { SimpleXlsxReader.parse(sesame_street_blog_io) }
+
+      it 'reads an xlsx string into a hash of {[sheet name] => [data]}' do
         _(subject.to_hash).must_equal(expected_result)
       end
     end


### PR DESCRIPTION
Fix #38 

In order to allow both file_paths (which might be strings) and io/buffer to be parsed, I split up `SimpleXlsxReader.open` and `SimpleXlsxReader.parse`.

The method to handle both possible inputs (and fail if neither is provided) is based on #33

On my M1 MBP, I did not see a noticeable difference in the linear-time performance test on master vs after these changes.