### PR TITLE
Treat typeless cells as numbers by default

### DIFF
--- a/lib/simple_xlsx_reader/loader.rb
+++ b/lib/simple_xlsx_reader/loader.rb
@@ -149,7 +149,15 @@ module SimpleXlsxReader
         # detected earlier and cast here by its standardized symbol
         ##
 
-        when :string, :unsupported
+        when :string
+          if (Integer(value) rescue false)
+            value.to_i
+          elsif (Float(value) rescue false)
+            value.to_f
+          else
+            value
+          end
+        when :unsupported
           value
         when :fixnum
           value.to_i

--- a/test/simple_xlsx_reader_test.rb
+++ b/test/simple_xlsx_reader_test.rb
@@ -818,6 +818,10 @@ describe SimpleXlsxReader do
                 <c r='I1' s='0'>
                   <v>GUI-made hyperlink</v>
                 </c>
+
+                <c r='J1' s='0'>
+                  <v>1</v>
+                </c>
               </row>
             </sheetData>
 
@@ -916,6 +920,10 @@ describe SimpleXlsxReader do
         )
       )
     end
+    
+    it "reads 'Generic' cells with numbers as numbers" do
+      _(@row[9]).must_equal 1
+    end
   end
 
   describe 'parsing documents with blank rows' do
@@ -927,7 +935,7 @@ describe SimpleXlsxReader do
             <sheetData>
             <row r="2" spans="1:1">
               <c r="A2" s="0">
-                <v>0</v>
+                <v>a</v>
               </c>
             </row>
             <row r="4" spans="1:1">
@@ -958,12 +966,12 @@ describe SimpleXlsxReader do
     it 'reads row data despite gaps in row numbering' do
       _(@rows).must_equal [
         [nil, nil, nil, nil],
-        ['0', nil, nil, nil],
+        ['a', nil, nil, nil],
         [nil, nil, nil, nil],
-        [nil, '1', nil, nil],
-        [nil, nil, '2', nil],
+        [nil, 1, nil, nil],
+        [nil, nil, 2, nil],
         [nil, nil, nil, nil],
-        [nil, nil, nil, '3']
+        [nil, nil, nil, 3]
       ]
     end
   end


### PR DESCRIPTION
This is the PR corresponding to Issue #40 .

When a cell does not have a type, the Office Open XML standard states that, by default, the type should be 'n' (number). This commit makes sure that, when that happens, the cell value is cast to Integer or Float by default - and, if not possible, left as a string.