### PR TITLE
Fix blank content when parsing docs from string

### DIFF
--- a/lib/simple_xlsx_reader/loader/sheet_parser.rb
+++ b/lib/simple_xlsx_reader/loader/sheet_parser.rb
@@ -31,9 +31,8 @@ module SimpleXlsxReader
         @url = nil # silence warnings
         @function = nil # silence warnings
         @capture = nil # silence warnings
+        @captured = nil # silence warnings
         @dimension = nil # silence warnings
-
-        @file_io.rewind # in case we've already parsed this once
 
         # In this project this is only used for GUI-made hyperlinks (as opposed
         # to FUNCTION-based hyperlinks). Unfortunately the're needed to parse
@@ -44,8 +43,9 @@ module SimpleXlsxReader
         if xrels_file&.grep(/hyperlink/)&.any?
           xrels_file.rewind
           load_gui_hyperlinks # represented as hyperlinks_by_cell
-          @file_io.rewind
         end
+
+        @file_io.rewind # in case we've already parsed this once
 
         Nokogiri::XML::SAX::Parser.new(self).parse(@file_io)
       end

--- a/test/performance_test.rb
+++ b/test/performance_test.rb
@@ -70,7 +70,7 @@ describe 'SimpleXlsxReader Benchmark' do
   let(:styles) do
     # s='0' above refers to the value of numFmtId at cellXfs index 0,
     # which is in this case 'General' type
-    styles =
+    _styles =
       <<-XML
         <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
           <cellXfs count="1">

--- a/test/simple_xlsx_reader_test.rb
+++ b/test/simple_xlsx_reader_test.rb
@@ -1031,6 +1031,52 @@ describe SimpleXlsxReader do
     end
   end
 
+  describe 'parsing documents with non-hyperlinked rels' do
+    let(:rels) do
+      [
+        Nokogiri::XML(
+          <<-XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>
+          XML
+        ).remove_namespaces!
+      ]
+    end
+
+    describe 'when document is opened as path' do
+      before do
+        @row = SimpleXlsxReader.open(xlsx.archive.path).sheets[0].rows.to_a[0]
+      end
+
+      it 'reads cell content' do
+        _(@row[0]).must_equal 'Cell A'
+      end
+    end
+
+    describe 'when document is parsed as a String' do
+      before do
+        output = File.binread(xlsx.archive.path)
+        @row = SimpleXlsxReader.parse(output).sheets[0].rows.to_a[0]
+      end
+
+      it 'reads cell content' do
+        _(@row[0]).must_equal 'Cell A'
+      end
+    end
+
+    describe 'when document is parsed as StringIO' do
+      before do
+        stream = StringIO.new(File.binread(xlsx.archive.path), 'rb')
+        @row = SimpleXlsxReader.parse(stream).sheets[0].rows.to_a[0]
+        stream.close
+      end
+
+      it 'reads cell content' do
+        _(@row[0]).must_equal 'Cell A'
+      end
+    end
+  end
+
   # https://support.microsoft.com/en-us/office/available-number-formats-in-excel-0afe8f52-97db-41f1-b972-4b46e9f1e8d2
   describe 'numeric fields styled as "General"' do
     let(:misc_numbers_path) do


### PR DESCRIPTION
### Reason
When document is passed as a `String` object (or `StringIO`, it seems) through the `SimpleXlsxReader.parse` method, the resulting document contains no data. The document in question must contain sheet rels, but must not have any hyperlink types for this to be observable in the latest library version.

### Reproduction
```ruby
file = File.binread('test/chunky_utf8.xlsx')

doc = SimpleXlsxReader.parse(file)

puts doc.to_hash['Companies export'].size # returns 0, should be 2
```

### Fix
There seems to be some kind of issue with input stream offset tracking in `rubyzip` or maybe Ruby itself when buffer is passed as a string. When the library tries to check for hyperlinks in sheet's xrels file, it shifts the sheet stream's offset as well. Curiously, the regular `IO` objects do not seem to be affected.

There are existing stream rewinds in the code, possibly to solve similar issues, but an edge case has slipped through when the xrels file exists, but it does not contain any hyperlink-related content.

A fix is to rewind sheet's stream unconditionally, before passing it to Nokogiri.

The Pull Request also contains a few tweaks to silence some warnings.