### PR TITLE
CI: Extend build matrix with Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This adds Ruby 3.3 to the build matrix.

3.0 is the last version in Security Updates mode, all others are EOL.