### PR TITLE
Parse links with numeric friendly name

### DIFF
--- a/lib/simple_xlsx_reader/hyperlink.rb
+++ b/lib/simple_xlsx_reader/hyperlink.rb
@@ -21,9 +21,9 @@ module SimpleXlsxReader
     attr_reader :url
 
     def initialize(url, friendly_name = nil)
-      @friendly_name = friendly_name
       @url = url
-      super(friendly_name || url)
+      @friendly_name = friendly_name&.to_s
+      super(@friendly_name || @url)
     end
   end
 end

--- a/test/simple_xlsx_reader_test.rb
+++ b/test/simple_xlsx_reader_test.rb
@@ -603,13 +603,18 @@ describe SimpleXlsxReader do
       describe 'with the url option' do
         let(:url) { 'http://www.example.com/hyperlink' }
         it 'creates a hyperlink with a string type' do
-          _(described_class.cast('A link', 'str', :string, url: url))
+          _(described_class.cast('A link', 'str', :string, url:))
             .must_equal SXR::Hyperlink.new(url, 'A link')
         end
 
         it 'creates a hyperlink with a shared string type' do
-          _(described_class.cast('2', 's', nil, shared_strings: %w[a b c], url: url))
+          _(described_class.cast('2', 's', nil, shared_strings: %w[a b c], url:))
             .must_equal SXR::Hyperlink.new(url, 'c')
+        end
+
+        it 'creates a hyperlink with a fixnum friendly_name' do
+          _(described_class.cast('123', nil, :fixnum, url:))
+            .must_equal SXR::Hyperlink.new(url, '123')
         end
       end
     end

--- a/test/simple_xlsx_reader_test.rb
+++ b/test/simple_xlsx_reader_test.rb
@@ -603,17 +603,17 @@ describe SimpleXlsxReader do
       describe 'with the url option' do
         let(:url) { 'http://www.example.com/hyperlink' }
         it 'creates a hyperlink with a string type' do
-          _(described_class.cast('A link', 'str', :string, url:))
+          _(described_class.cast('A link', 'str', :string, url: url))
             .must_equal SXR::Hyperlink.new(url, 'A link')
         end
 
         it 'creates a hyperlink with a shared string type' do
-          _(described_class.cast('2', 's', nil, shared_strings: %w[a b c], url:))
+          _(described_class.cast('2', 's', nil, shared_strings: %w[a b c], url: url))
             .must_equal SXR::Hyperlink.new(url, 'c')
         end
 
         it 'creates a hyperlink with a fixnum friendly_name' do
-          _(described_class.cast('123', nil, :fixnum, url:))
+          _(described_class.cast('123', nil, :fixnum, url: url))
             .must_equal SXR::Hyperlink.new(url, '123')
         end
       end


### PR DESCRIPTION
Prevent a SimpleXlsxReader::CellLoadError (no implicit conversion of Integer into String) when the casted value (friendly name) is not a string